### PR TITLE
Prompt user to save game output

### DIFF
--- a/main.py
+++ b/main.py
@@ -516,17 +516,15 @@ def gameLoop(matrix, ants, config):
         printMap(matrix)
         print("Round:", lap, "Team 1:", str(team1Points), "Team 2:", str(team2Points))
         
-        # Add this round to an output list
+        # Add this round to an output string
         gameOutput += (
             f"==============================\n"
             f"ROUND {lap}\n"
             f"NORTH {team1Points}\n"
             f"SOUTH {team2Points}\n"
-            f"=============================\n"
+            f"=========================\n"
             f"{''.join(f'{line}\n' for line in matrixToStrList(matrix))}"
-            f"=============================\n"
         )
-
 
         # Receive messages from ants from this round
         for a in ants:

--- a/main.py
+++ b/main.py
@@ -373,6 +373,8 @@ def gameLoop(matrix, ants, config):
     team1Messages = []
     team2Messages = []
     
+    gameOutput = f"SIZE {len(matrix[0])} {len(matrix)}\n"
+    
     pool = ThreadPoolExecutor() # Can impose limits on number of threads
     
     transformXY = { "NORTH": lambda x, y: (x, y-1),
@@ -513,6 +515,18 @@ def gameLoop(matrix, ants, config):
         placeAnts(matrix, ants)
         printMap(matrix)
         print("Round:", lap, "Team 1:", str(team1Points), "Team 2:", str(team2Points))
+        
+        # Add this round to an output list
+        gameOutput += (
+            f"==============================\n"
+            f"ROUND {lap}\n"
+            f"NORTH {team1Points}\n"
+            f"SOUTH {team2Points}\n"
+            f"=============================\n"
+            f"{''.join(f'{line}\n' for line in matrixToStrList(matrix))}"
+            f"=============================\n"
+        )
+
 
         # Receive messages from ants from this round
         for a in ants:
@@ -534,9 +548,18 @@ def gameLoop(matrix, ants, config):
                     team2Messages += msgs
 
         ants[:] = [a for a in ants if a.alive] # Remove the dead ants
+        
+    gameOutput += "==============================\n"
 
     pool.shutdown()
     print("\n==== Final score ====\nTeam 1: " + str(team1Points) + " Team 2 : " + str(team2Points))
+    
+    # Prompt user to save full game output
+    save = input("Save game output? (yes/<enter>) ")
+    if save.upper() == "YES":
+        filename = input("Enter filename: ")
+        with open(filename, "w+") as outfile:
+            outfile.write(gameOutput)
 
 def promptSaveMap(initialMatrix):
     """Prompt user to save map for a future game"""


### PR DESCRIPTION
**Description:**
This PR introduces a new feature that prompts users at the end of a game whether they would like to save the entire game output to a file. If the user agrees, the full game output (including round-by-round details and scores) will be written to a text file in the desired location.

**Key Changes:**
- Added a prompt at the end of the game asking if the user would like to save the output.
- If the user types "yes", they will be prompted to enter a filename as a _relative path_.
- The game output is written in a human-readable (and easily parseable) format, including:
  - The current round number
  - Scores for both teams **for each round**
  - The complete game board for each round

**How to Test:**
- Run the game as usual.
- After the final round, you will be asked if you'd like to save the game output.
- If you choose "yes", type the _relative path_ of the file to which you'd like to save the output.
- Verify that the game output is correctly written to the chosen file.

Closes Issue: #1 