### PR TITLE
Fix newline escape error in nested F-string for game output recording

### DIFF
--- a/main.py
+++ b/main.py
@@ -529,8 +529,8 @@ def gameLoop(matrix, ants, config):
             f"NORTH {team1Points}\n"
             f"SOUTH {team2Points}\n"
             f"=========================\n"
-            f"{''.join(f'{line}\n' for line in matrixToStrList(matrix))}"
         )
+        gameOutput += ''.join(f'{line}\n' for line in matrixToStrList(matrix))
 
         # Receive messages from ants from this round
         for a in ants:


### PR DESCRIPTION
**Description:**
This PR fixes a bug that prevented the game output from being recorded each round due to a newline escape character (`\n`) within a nested F-string. Older versions of Python seem to have different syntax rules for F-strings, so this change ensures compatibility with all modern Python versions.  The bug was discovered when using Python 3.10.12 on Pop!_OS but was not present in the latest version, 3.13, on both Windows and Linux.

**Key Changes:**
- The program will now append the string representation of the current round's board separate from the round number and current scores to remove the use of a nested F-string.
