### PR TITLE
Rename typo reference to 'game_output' on line 537

### DIFF
--- a/main.py
+++ b/main.py
@@ -534,7 +534,7 @@ def game_loop(matrix, ants, config):
             f"SOUTH {team2_points}\n"
             f"=========================\n"
         )
-        gameOutput += ''.join(f'{line}\n' for line in matrixToStrList(matrix))
+        game_output += ''.join(f'{line}\n' for line in matrixToStrList(matrix))
 
         # Receive messages from ants from this round
         for a in ants:


### PR DESCRIPTION
**Description:**
This PR fixes a [variable naming typo on line 537 of main.py](https://github.com/Grace-H/antcode/blob/7dd2e318854566bbab1500353823d12a00bee4ca/main.py#L537) causing the simulation to fail with an UnboundLocalError.

**Key Changes:**
- The one reference to `gameOutput` has been correctly changed to `game_output`.
