### PR TITLE
Fix naming issue with 'matrix_to_str_list' function on line 537

### DIFF
--- a/main.py
+++ b/main.py
@@ -534,7 +534,7 @@ def game_loop(matrix, ants, config):
             f"SOUTH {team2_points}\n"
             f"=========================\n"
         )
-        game_output += ''.join(f'{line}\n' for line in matrixToStrList(matrix))
+        game_output += ''.join(f'{line}\n' for line in matrix_to_str_list(matrix))
 
         # Receive messages from ants from this round
         for a in ants:


### PR DESCRIPTION
Oops, I didn't catch this in the last PR... 😅

**Description:**
This PR fixes a [function naming typo on line 537 of main.py](https://github.com/Grace-H/antcode/blob/28fd19b5a568d9436eb8e6ff20b904b2bbc07cec/main.py#L537) causing the simulation to fail with an UnboundLocalError.

**Key Changes:**
- The one reference to `matrixToStrList()` has been correctly changed to `matrix_to_str_list()`.
