### PR TITLE
fix: update VerticalStrat.one_step to accept 'food' parameter

### DIFF
--- a/VerticalStrat.py
+++ b/VerticalStrat.py
@@ -15,7 +15,7 @@ class VerticalStrat(AntStrategy):
         '''This ant doesn't send any messages'''
         return []
     
-    def one_step(self, x, y, vision):
+    def one_step(self, x, y, vision, food):
         '''Return next move, changing direction when a boundary is reached'''
         if self.direction == "SOUTH":
             if x < self.max_y:


### PR DESCRIPTION
**Description:**
This PR fixes a [function parameter issue on VerticalStrat.py line 18](https://github.com/Grace-H/antcode/blob/6f84c02cc8f7ac07102ec65352626bbe952b4812/VerticalStrat.py#L18). `VerticalStrat`'s method override `one_step()` from the parent class `AntStrategy` did not include the 5th parameter `food`.  Thus, the ant was not present in any games because it was immediately killed for throwing a `TypeError`.

**Key Changes:**
- `VerticalStrat`'s method `one_step()` from the parent class `AntStrategy` is now properly implemented with all five parameters present.
